### PR TITLE
chore: fix the output of `watch -i`

### DIFF
--- a/etcdctl/ctlv3/command/watch_command.go
+++ b/etcdctl/ctlv3/command/watch_command.go
@@ -105,7 +105,7 @@ func watchInteractiveFunc(cmd *cobra.Command, osArgs []string, envKey, envRange 
 
 		args := Argify(l)
 		if len(args) < 1 {
-			fmt.Fprintf(os.Stderr, "Invalid command: %s (watch and progress supported)\n", l)
+			fmt.Fprintf(os.Stderr, "Invalid command: %s (`watch` and `progress` supported)\n", l)
 			continue
 		}
 		switch args[0] {
@@ -131,7 +131,7 @@ func watchInteractiveFunc(cmd *cobra.Command, osArgs []string, envKey, envRange 
 				cobrautl.ExitWithError(cobrautl.ExitError, err)
 			}
 		default:
-			fmt.Fprintf(os.Stderr, "Invalid command %s (only support watch)\n", l)
+			fmt.Fprintf(os.Stderr, "Invalid command %s (only support `watch` & `progress`)\n", l)
 			continue
 		}
 	}


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
![image](https://github.com/user-attachments/assets/2bd83dc4-d635-4cb0-bfb5-a569858d21bd)
Although the interactive mode of `etcdctl watch` supports `progress` command now, the output is a little bit out-of-date :(